### PR TITLE
Added forgotten fields in Invoice entity. 

### DIFF
--- a/src/main/java/com/kindergarden/app/dao/InvoiceRepository.java
+++ b/src/main/java/com/kindergarden/app/dao/InvoiceRepository.java
@@ -4,12 +4,13 @@ import com.kindergarden.app.entity.Invoice;
 import com.kindergarden.app.entity.Parent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 public interface InvoiceRepository extends JpaRepository<Invoice, UUID> {
 
-    List<Invoice> findAllByInvoiceDate_MonthValue(int month);
+    List<Invoice> findAllByInvoiceDate(LocalDate localDate);
 
     List<Invoice> findAllByParent(Parent parent);
 

--- a/src/main/java/com/kindergarden/app/entity/Invoice.java
+++ b/src/main/java/com/kindergarden/app/entity/Invoice.java
@@ -25,6 +25,12 @@ public class Invoice {
     //TODO create invoice number generator
     private String invoiceNumber;
 
+    private String clientName;
+
+    private String addressLine1;
+
+    private String addressLine2;
+
     private int dinnerCounter;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
@@ -41,4 +47,19 @@ public class Invoice {
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     private List<Position> positions;
+
+
+    public void setClientName(String clientName) {
+
+        this.clientName = (getClientName()==null) ? parent.getFirstName() + " " + parent.getLastName() : getClientName();
+    }
+
+    public void setAddressLine1(String addressLine1) {
+        this.addressLine1 = (getAddressLine1()==null) ? parent.getAddressStreet() : getAddressLine1();
+    }
+
+    public void setAddressLine2(String addressLine2) {
+        this.addressLine2 = (getAddressLine2()==null) ? parent.getAddressPostalCode() + " " + parent.getAddressCity() : getAddressLine2();
+    }
+
 }


### PR DESCRIPTION
Concept of storage invoices is that the invoice data is set once and could be changed only on single invoice edition level. Every time when it will be called invoices list, basic invoice data (like client name, address etc.) cannot be taken from Parent entity directly, but should be taken from Invoice field entity (in some sense hardcoded).

Also correct method name in InvoiceRepository.